### PR TITLE
Add in env variable to control job engine pull policy

### DIFF
--- a/helm/templates/agent-deployment.yaml
+++ b/helm/templates/agent-deployment.yaml
@@ -67,8 +67,8 @@ spec:
                   fieldPath: spec.nodeName
             - name: MY_NAMESPACE
               value: {{ include "nuvlaedge.namespace" . }}
-            - name: TEST_IMAGE_PULL_POLICY
-              value: {{ .Values.TEST_JOB_ENGINE_PULL_POLICY | default "IfNotPresent" | quote }}
+            - name: JOB_ENGINE_IMAGE_PULL_POLICY
+              value: {{ .Values._NE_JOB_ENGINE_PULL_POLICY | default "IfNotPresent" | quote }}
           volumeMounts:
             - mountPath: /rootfs
               name: rootfs

--- a/helm/templates/agent-deployment.yaml
+++ b/helm/templates/agent-deployment.yaml
@@ -67,6 +67,8 @@ spec:
                   fieldPath: spec.nodeName
             - name: MY_NAMESPACE
               value: {{ include "nuvlaedge.namespace" . }}
+            - name: TEST_JOB_ENGINE_PULL_POLICY
+              value: {{ .Values.TEST_IMAGE_PULL_POLICY | default "IfNotPresent" | quote }}
           volumeMounts:
             - mountPath: /rootfs
               name: rootfs

--- a/helm/templates/agent-deployment.yaml
+++ b/helm/templates/agent-deployment.yaml
@@ -67,8 +67,8 @@ spec:
                   fieldPath: spec.nodeName
             - name: MY_NAMESPACE
               value: {{ include "nuvlaedge.namespace" . }}
-            - name: TEST_JOB_ENGINE_PULL_POLICY
-              value: {{ .Values.TEST_IMAGE_PULL_POLICY | default "IfNotPresent" | quote }}
+            - name: TEST_IMAGE_PULL_POLICY
+              value: {{ .Values.TEST_JOB_ENGINE_PULL_POLICY | default "IfNotPresent" | quote }}
           volumeMounts:
             - mountPath: /rootfs
               name: rootfs

--- a/helm/templates/agent-deployment.yaml
+++ b/helm/templates/agent-deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - name: MY_NAMESPACE
               value: {{ include "nuvlaedge.namespace" . }}
             - name: JOB_ENGINE_IMAGE_PULL_POLICY
-              value: {{ .Values._NE_JOB_ENGINE_PULL_POLICY | default "IfNotPresent" | quote }}
+              value: {{ .Values._NE_JOB_ENGINE_PULL_POLICY | default "Always" | quote }}
           volumeMounts:
             - mountPath: /rootfs
               name: rootfs

--- a/helm/templates/agent-deployment.yaml
+++ b/helm/templates/agent-deployment.yaml
@@ -67,8 +67,8 @@ spec:
                   fieldPath: spec.nodeName
             - name: MY_NAMESPACE
               value: {{ include "nuvlaedge.namespace" . }}
-            - name: JOB_ENGINE_IMAGE_PULL_POLICY
-              value: {{ .Values._NE_JOB_ENGINE_PULL_POLICY | default "Always" | quote }}
+            - name: JOB_IMAGE_PULL_POLICY
+              value: {{ .Values.JOB_IMAGE_PULL_POLICY | default "Always" | quote }}
           volumeMounts:
             - mountPath: /rootfs
               name: rootfs


### PR DESCRIPTION
Adding the environment variable that can be set to control how the pull policy for jobs spawned by agent is controlled