### PR TITLE
Set the revision history limit and remove deployment suffix 

### DIFF
--- a/helm/templates/agent-deployment.yaml
+++ b/helm/templates/agent-deployment.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       component: agent
-  revisionHistoryLimit: 1 # Default to 10 if not specified
+  revisionHistoryLimit: 0 # Default to 10 if not specified
   template:
     metadata:
       labels:

--- a/helm/templates/agent-deployment.yaml
+++ b/helm/templates/agent-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: agent{{ .Values.deploymentSuffix }}
+  name: agent
   namespace: {{ include "nuvlaedge.namespace" . }}
   labels:
     {{- include "nuvlaedge.labels" . | nindent 4 }}

--- a/helm/templates/agent-deployment.yaml
+++ b/helm/templates/agent-deployment.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       component: agent
-  revisionHistoryLimit: 0 # Default to 10 if not specified
+  revisionHistoryLimit: {{ .Values.deploymentRevHistLimit }} # Default to 10 if not specified
   template:
     metadata:
       labels:

--- a/helm/templates/agent-deployment.yaml
+++ b/helm/templates/agent-deployment.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       component: agent
+  revisionHistoryLimit: 1 # Default to 10 if not specified
   template:
     metadata:
       labels:

--- a/helm/templates/agent-deployment.yaml
+++ b/helm/templates/agent-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: agent-deployment
+  name: agent{{ .Values.deploymentSuffix }}
   namespace: {{ include "nuvlaedge.namespace" . }}
   labels:
     {{- include "nuvlaedge.labels" . | nindent 4 }}

--- a/helm/templates/data-gateway-deployment.yaml
+++ b/helm/templates/data-gateway-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: data-gateway{{ .Values.deploymentSuffix }}
+  name: data-gateway
   namespace: {{ include "nuvlaedge.namespace" . }}
   labels:
     {{- include "nuvlaedge.labels" . | nindent 4 }}

--- a/helm/templates/data-gateway-deployment.yaml
+++ b/helm/templates/data-gateway-deployment.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       component: data-gateway
+  revisionHistoryLimit: 1 
   template:
     metadata:
       labels:

--- a/helm/templates/data-gateway-deployment.yaml
+++ b/helm/templates/data-gateway-deployment.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       component: data-gateway
-  revisionHistoryLimit: 1 
+  revisionHistoryLimit: {{ .Values.deploymentRevHistLimit }} 
   template:
     metadata:
       labels:

--- a/helm/templates/data-gateway-deployment.yaml
+++ b/helm/templates/data-gateway-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: data-gateway-deployment
+  name: data-gateway{{ .Values.deploymentSuffix }}
   namespace: {{ include "nuvlaedge.namespace" . }}
   labels:
     {{- include "nuvlaedge.labels" . | nindent 4 }}

--- a/helm/templates/kubernetes-credentials-manager-job.yaml
+++ b/helm/templates/kubernetes-credentials-manager-job.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "nuvlaedge.labels" . | nindent 4 }}
 spec:
-  revisionHistoryLimit: 1 
+  revisionHistoryLimit: {{ .Values.deploymentRevHistLimit }} 
   ttlSecondsAfterFinished: {{ .Values.credManager.ttlJobFinished }}
   template:
     spec:

--- a/helm/templates/kubernetes-credentials-manager-job.yaml
+++ b/helm/templates/kubernetes-credentials-manager-job.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "nuvlaedge.labels" . | nindent 4 }}
 spec:
+  revisionHistoryLimit: 1 
   ttlSecondsAfterFinished: {{ .Values.credManager.ttlJobFinished }}
   template:
     spec:

--- a/helm/templates/system-manager-deployment.yaml
+++ b/helm/templates/system-manager-deployment.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       component: system-manager
+  revisionHistoryLimit: 1 
   template:
     metadata:
       labels:

--- a/helm/templates/system-manager-deployment.yaml
+++ b/helm/templates/system-manager-deployment.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       component: system-manager
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: {{ .Values.deploymentRevHistLimit }} 
   template:
     metadata:
       labels:

--- a/helm/templates/system-manager-deployment.yaml
+++ b/helm/templates/system-manager-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: system-manager{{ .Values.deploymentSuffix }}
+  name: system-manager
   namespace: {{ include "nuvlaedge.namespace" . }}
   labels:
     {{- include "nuvlaedge.labels" . | nindent 4 }}

--- a/helm/templates/system-manager-deployment.yaml
+++ b/helm/templates/system-manager-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: system-manager-deployment
+  name: system-manager{{ .Values.deploymentSuffix }}
   namespace: {{ include "nuvlaedge.namespace" . }}
   labels:
     {{- include "nuvlaedge.labels" . | nindent 4 }}

--- a/helm/templates/system-manager-deployment.yaml
+++ b/helm/templates/system-manager-deployment.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       component: system-manager
-  revisionHistoryLimit: 1 
+  revisionHistoryLimit: 0
   template:
     metadata:
       labels:

--- a/helm/templates/vpn-client-deployment.yaml
+++ b/helm/templates/vpn-client-deployment.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     matchLabels:
       component: {{ .Values.vpnClientComponentName }}
-  revisionHistoryLimit: 1 
+  revisionHistoryLimit: {{ .Values.deploymentRevHistLimit }} 
   template:
     metadata:
       labels:

--- a/helm/templates/vpn-client-deployment.yaml
+++ b/helm/templates/vpn-client-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vpn-client{{ .Values.deploymentSuffix }}
+  name: vpn-client
   namespace: {{ include "nuvlaedge.namespace" . }}
   labels:
     {{- include "nuvlaedge.labels" . | nindent 4 }}

--- a/helm/templates/vpn-client-deployment.yaml
+++ b/helm/templates/vpn-client-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vpn-client-deployment
+  name: vpn-client{{ .Values.deploymentSuffix }}
   namespace: {{ include "nuvlaedge.namespace" . }}
   labels:
     {{- include "nuvlaedge.labels" . | nindent 4 }}

--- a/helm/templates/vpn-client-deployment.yaml
+++ b/helm/templates/vpn-client-deployment.yaml
@@ -11,6 +11,7 @@ spec:
   selector:
     matchLabels:
       component: {{ .Values.vpnClientComponentName }}
+  revisionHistoryLimit: 1 
   template:
     metadata:
       labels:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,6 +10,8 @@ nuvlaedgeVolumeHostPath: /var/lib/nuvlaedge
 
 deploymentRevHistLimit: 0
 
+deploymentSuffix: "-jsw-deployment"
+
 nuvlaedge:
   image:
     registry: ""

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,7 +8,7 @@ vpnClientComponentName: vpn-client
 
 nuvlaedgeVolumeHostPath: /var/lib/nuvlaedge
 
-deploymentRevHistLimit: 2
+deploymentRevHistLimit: 0
 
 nuvlaedge:
   image:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,8 +10,6 @@ nuvlaedgeVolumeHostPath: /var/lib/nuvlaedge
 
 deploymentRevHistLimit: 0
 
-deploymentSuffix: ""
-
 nuvlaedge:
   image:
     registry: ""

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,7 +10,7 @@ nuvlaedgeVolumeHostPath: /var/lib/nuvlaedge
 
 deploymentRevHistLimit: 0
 
-deploymentSuffix: "-jsw-deployment"
+deploymentSuffix: ""
 
 nuvlaedge:
   image:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,6 +8,8 @@ vpnClientComponentName: vpn-client
 
 nuvlaedgeVolumeHostPath: /var/lib/nuvlaedge
 
+deploymentRevHistLimit: 2
+
 nuvlaedge:
   image:
     registry: ""


### PR DESCRIPTION
The pull request sets the number of revisions of a deployment to zero.
It also removes the suffix "-deployment" from the deployments of the NuvlaEdge pods 