### PR TITLE
fix: update certificate approval command condition in NOTES.txt

### DIFF
--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -6,7 +6,7 @@ The NuvlaEdge has just been installed on your Kubernetes node {{ .Values.kuberne
    for the certificate used to manage the NuvlaEdge instance please run the
    following command as system admin of the K8s cluster:{{printf "\n\n" }}
 
-   {{- if .Values.SET_MULTIPLE -}}
+   {{- if eq .Values.credManager.csr_name "nuvlaedge-csr" -}}
      kubectl certificate approve {{ .Values.credManager.csr_name }}{{ printf "-" }}{{ include "nuvlaedge.uuid" . }}{{printf "\n\n" }}
    {{- else -}}
      kubectl certificate approve {{ .Values.credManager.csr_name }}{{printf "\n\n" }}


### PR DESCRIPTION
This works in tandem with https://github.com/nuvlaedge/nuvlaedge/pull/227

The default CSR name is `nuvlaedge-csr`. It is defined as default in [`values.yaml`](https://github.com/nuvlaedge/deployment/blob/main/helm/values.yaml#L32) and assumed as the default in `kubernetes-credentail-manager.sh` in this PR https://github.com/nuvlaedge/nuvlaedge/pull/227. In the case of the default CSR name, `kubernetes-credentail-manager.sh` and `NOTES.txt` generate CSR name as `nuvlaedge-csr-<NE UUID>`. Otherwise, the value provided in `values.yaml` (that is different from the assumed default) will be used as the name of CSR.
